### PR TITLE
Remove `.`s from emoji names

### DIFF
--- a/utilities/constants.js
+++ b/utilities/constants.js
@@ -36,6 +36,11 @@ const OWNER = "173839815400357888";
 const BUTTONROWMAXLENGTH = 5;
 const MAXIMUMBUTTONROWS = 5;
 
+/**
+ * Regex of characters not allowed in emoji names, such as spaces or periods.
+ */
+const DISALLOWED_EMOJI_CHARACTERS_REGEX = [/ \./]
+
 module.exports = {
     GUILDS,
     CHANNELS,
@@ -44,4 +49,5 @@ module.exports = {
     OWNER,
     BUTTONROWMAXLENGTH,
     MAXIMUMBUTTONROWS,
+    DISALLOWED_EMOJI_CHARACTERS_REGEX,
 };

--- a/utilities/roleup.js
+++ b/utilities/roleup.js
@@ -3,6 +3,7 @@ const {
     BUTTONROWMAXLENGTH,
     GUILDS,
     MAXIMUMBUTTONROWS,
+    DISALLOWED_EMOJI_CHARACTERS_REGEX,
 } = require("./constants");
 
 const MAXROLEROWS = MAXIMUMBUTTONROWS - 1;
@@ -166,7 +167,7 @@ function makeEmojiURL(role) {
 }
 
 function emojify(text) {
-    return text.replaceAll(" ", "_");
+    return text.replaceAll(DISALLOWED_EMOJI_CHARACTERS_REGEX, "_");
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes roleup crashing when the role has a period in the name

Error:
![image](https://github.com/ecfidler/shigure-js/assets/12519846/5b79853e-8769-4e87-9665-6b51f50a1527)
