### PR TITLE
Update discord.js to 14.17.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Secrets
+auth.json
+
 # Logs
 logs
 *.log

--- a/commands/Find Source.js
+++ b/commands/Find Source.js
@@ -2,6 +2,7 @@ const {
     EmbedBuilder,
     AttachmentBuilder,
     ApplicationCommandType,
+    Colors,
 } = require("discord.js");
 const { CHANNELS, GUILDS } = require("../utilities/constants.js");
 const SauceNAO = require("saucenao");
@@ -74,7 +75,7 @@ async function action(client, interaction) {
 function formatSauce(payload, thumbnail) {
     const sauce = new EmbedBuilder()
         .setTitle("Source(s) found:")
-        .setColor("BLURPLE")
+        .setColor(Colors.Blurple)
         .setAuthor(SAUCE_NAO_AUTHOR)
         .setThumbnail(thumbnail)
         .setFooter({
@@ -158,7 +159,7 @@ function errorEmbed(code) {
 
     const err = new EmbedBuilder()
         .setTitle("Error")
-        .setColor("RED")
+        .setColor(Colors.Red)
         .setAuthor(SAUCE_NAO_AUTHOR)
         .setDescription(`${text} error, Code: ${code}`)
         .setFooter({

--- a/commands/Pin to lowlights.js
+++ b/commands/Pin to lowlights.js
@@ -1,4 +1,8 @@
-const { MessageEmbed } = require("discord.js");
+const {
+    EmbedBuilder,
+    ApplicationCommandType,
+    ApplicationCommandOptionType,
+} = require("discord.js");
 const {
     CHANNELS,
     GUILDS,
@@ -13,15 +17,17 @@ const commandData = {
     permissions: [
         {
             id: ROLES.MAJOR,
-            type: "ROLE",
+            type: ApplicationCommandOptionType.Role,
             permission: true,
         },
     ],
-    type: "MESSAGE",
+    type: ApplicationCommandType.Message,
 };
 
 async function action(client, interaction) {
-    const msg = await interaction.channel.messages.fetch(interaction.targetId);
+    const msg = await interaction.channel.messages.fetch({
+        message: interaction.targetId,
+    });
     const mbr = await interaction.guild.members.fetch(msg.author.id);
 
     await pinMessage(msg, mbr, interaction, client);
@@ -41,12 +47,12 @@ async function pinMessage(msg, mbr, interaction, client) {
 }
 
 function createPinEmbed(message, member, pinner) {
-    const pinEmbed = new MessageEmbed()
+    const pinEmbed = new EmbedBuilder()
         .setColor(member.displayHexColor)
         .setTitle("Message Content")
         .setAuthor({
             name: member.displayName,
-            iconURL: member.user.displayAvatarURL({ dynamic: true }),
+            iconURL: member.user.displayAvatarURL({}),
             url: message.url,
         })
         .setDescription(message.content)

--- a/commands/Pin to lowlights.js
+++ b/commands/Pin to lowlights.js
@@ -10,13 +10,24 @@ const {
     ROLES,
 } = require("../utilities/constants.js");
 
-const guild = GUILDS.WHID;
+const lowlightChannelByGuild = {
+    [GUILDS.WHID]: CHANNELS.LOW,
+    [GUILDS.BEN_TESTING]: CHANNELS.LOW_TEST,
+};
+const guilds = Object.keys(lowlightChannelByGuild);
 
 const commandData = {
     defaultPermission: false,
     permissions: [
+        // whid
         {
             id: ROLES.MAJOR,
+            type: ApplicationCommandOptionType.Role,
+            permission: true,
+        },
+        // Ben testing server
+        {
+            id: "1335083523249406012",
             type: ApplicationCommandOptionType.Role,
             permission: true,
         },
@@ -43,7 +54,9 @@ async function action(client, interaction) {
 
 async function pinMessage(msg, mbr, interaction, client) {
     const embed = createPinEmbed(msg, mbr, interaction.member.displayName);
-    await client.channels.cache.get(CHANNELS.LOW).send({ embeds: [embed] });
+    await client.channels.cache
+        .get(lowlightChannelByGuild[interaction.guildId])
+        .send({ embeds: [embed] });
 }
 
 function createPinEmbed(message, member, pinner) {
@@ -68,4 +81,8 @@ function createPinEmbed(message, member, pinner) {
     return pinEmbed;
 }
 
-module.exports = { commandData, action, guild };
+module.exports = {
+    commandData,
+    action,
+    guilds,
+};

--- a/commands/echo.js
+++ b/commands/echo.js
@@ -1,4 +1,8 @@
 const { GUILDS } = require("../utilities/constants.js");
+const {
+    ApplicationCommandType,
+    ApplicationCommandOptionType,
+} = require("discord.js");
 
 const guild = GUILDS.WHID;
 
@@ -8,11 +12,11 @@ const commandData = {
         {
             name: "content",
             description: "the message you want echoed",
-            type: "STRING",
+            type: ApplicationCommandOptionType.String,
             required: true,
         },
     ],
-    type: "CHAT_INPUT",
+    type: ApplicationCommandType.ChatInput,
 };
 
 async function action(client, interaction) {

--- a/commands/pasta.js
+++ b/commands/pasta.js
@@ -1,6 +1,7 @@
 const snoowrap = require("snoowrap");
 const { GUILDS } = require("../utilities/constants.js");
 const auth = require("../auth.json");
+const { ApplicationCommandType } = require("discord.js");
 
 // Reddit Client
 const redditClient = new snoowrap({
@@ -18,7 +19,7 @@ const guild = GUILDS.WHID;
 
 const commandData = {
     description: "gets a random piece of artwork from r/copypasta.",
-    type: "CHAT_INPUT",
+    type: ApplicationCommandType.ChatInput,
 };
 
 async function action(client, interaction) {

--- a/commands/pasta.js
+++ b/commands/pasta.js
@@ -4,13 +4,20 @@ const auth = require("../auth.json");
 const { ApplicationCommandType } = require("discord.js");
 
 // Reddit Client
-const redditClient = new snoowrap({
-    userAgent: auth.RuserAgent,
-    clientId: auth.RclientId,
-    clientSecret: auth.RclientSecret,
-    username: auth.Rusername,
-    password: auth.Rpassword,
-});
+let redditClient;
+let getRedditClientSingleton = () => {
+    if (redditClient == null) {
+        redditClient = new snoowrap({
+            userAgent: auth.RuserAgent,
+            clientId: auth.RclientId,
+            clientSecret: auth.RclientSecret,
+            username: auth.Rusername,
+            password: auth.Rpassword,
+        });
+    }
+
+    return redditClient;
+};
 
 const errorMessage =
     "OOPSIE WOOPSIE!! Uwu We made a fucky wucky!! A wittle fucko boingo! The code monkeys at our headquarters are working VEWY HAWD to fix this!\n_~error message_";
@@ -23,9 +30,17 @@ const commandData = {
 };
 
 async function action(client, interaction) {
+    const enablePastaCommand = checkAuthorizationHeadersForReddit(auth);
+    if (!enablePastaCommand) {
+        console.warning(
+            "No reddit API credentials provided. Reddit features will not work"
+        );
+        return;
+    }
+
     await interaction.deferReply();
 
-    redditClient
+    getRedditClientSingleton()
         .getRandomSubmission("copypasta")
         .then(
             async value => {
@@ -53,6 +68,16 @@ async function action(client, interaction) {
         .catch(err => {
             console.log(err);
         });
+}
+
+function checkAuthorizationHeadersForReddit(authObject) {
+    return (
+        authObject.RuserAgent != null &&
+        authObject.RclientId != null &&
+        authObject.RclientSecret != null &&
+        authObject.Rusername != null &&
+        authObject.Rpassword != null
+    );
 }
 
 module.exports = { commandData, action, guild };

--- a/commands/roleup.js
+++ b/commands/roleup.js
@@ -2,6 +2,7 @@ const {
     EmbedBuilder,
     ApplicationCommandType,
     ApplicationCommandOptionType,
+    Colors,
 } = require("discord.js");
 const { GUILDS } = require("../utilities/constants.js");
 const { getButtonRows, getRoles } = require("../utilities/roleup.js");
@@ -36,7 +37,7 @@ const commandData = {
     type: ApplicationCommandType.ChatInput,
 };
 
-const roleMenuHeader = new EmbedBuilder().setColor("BLURPLE").setAuthor({
+const roleMenuHeader = new EmbedBuilder().setColor(Colors.Blurple).setAuthor({
     name: "Click on a grey role to add it, click on a green role to remove it!",
 }); // TODO: add author icon?
 

--- a/commands/roleup.js
+++ b/commands/roleup.js
@@ -1,4 +1,8 @@
-const { MessageEmbed } = require("discord.js");
+const {
+    EmbedBuilder,
+    ApplicationCommandType,
+    ApplicationCommandOptionType,
+} = require("discord.js");
 const { GUILDS } = require("../utilities/constants.js");
 const { getButtonRows, getRoles } = require("../utilities/roleup.js");
 
@@ -25,14 +29,14 @@ const commandData = {
                     value: "schools",
                 },
             ],
-            type: "STRING",
+            type: ApplicationCommandOptionType.String,
             required: true,
         },
     ],
-    type: "CHAT_INPUT",
+    type: ApplicationCommandType.ChatInput,
 };
 
-const roleMenuHeader = new MessageEmbed().setColor("BLURPLE").setAuthor({
+const roleMenuHeader = new EmbedBuilder().setColor("BLURPLE").setAuthor({
     name: "Click on a grey role to add it, click on a green role to remove it!",
 }); // TODO: add author icon?
 

--- a/commands/speakeasy.js
+++ b/commands/speakeasy.js
@@ -1,4 +1,4 @@
-const { MessageEmbed } = require("discord.js");
+const { EmbedBuilder, ApplicationCommandType } = require("discord.js");
 const { hasRole } = require("../commands/roleup");
 
 const { GUILDS, ROLES } = require("../utilities/constants.js");
@@ -7,7 +7,7 @@ const guild = GUILDS.YONI;
 
 const commandData = {
     description: "toggle the NSFW role on yourself",
-    type: "CHAT_INPUT",
+    type: ApplicationCommandType.ChatInput,
 };
 
 async function action(client, interaction) {
@@ -37,10 +37,10 @@ async function action(client, interaction) {
 }
 
 function makeEmbed(text) {
-    let embed = new MessageEmbed()
+    let embed = new EmbedBuilder()
         .setDescription(text)
         .setColor("BLURPLE")
-        .setAuthor("/speakeasy")
+        .setAuthor({ name: "/speakeasy" })
         .setTimestamp();
 
     return embed;

--- a/commands/speakeasy.js
+++ b/commands/speakeasy.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder, ApplicationCommandType } = require("discord.js");
+const { EmbedBuilder, ApplicationCommandType, Colors } = require("discord.js");
 const { hasRole } = require("../commands/roleup");
 
 const { GUILDS, ROLES } = require("../utilities/constants.js");
@@ -39,7 +39,7 @@ async function action(client, interaction) {
 function makeEmbed(text) {
     let embed = new EmbedBuilder()
         .setDescription(text)
-        .setColor("BLURPLE")
+        .setColor(Colors.Blurple)
         .setAuthor({ name: "/speakeasy" })
         .setTimestamp();
 

--- a/commands/test.js
+++ b/commands/test.js
@@ -1,3 +1,8 @@
+const {
+    ApplicationCommandType,
+    ApplicationCommandOptionType,
+} = require("discord.js");
+
 const guild = "173840048343482368";
 
 const commandData = {
@@ -20,11 +25,11 @@ const commandData = {
                     value: "pong",
                 },
             ],
-            type: "STRING",
+            type: ApplicationCommandOptionType.String,
             required: true,
         },
     ],
-    type: "CHAT_INPUT",
+    type: ApplicationCommandType.ChatInput,
 };
 
 async function action(client, interaction) {

--- a/index.js
+++ b/index.js
@@ -29,15 +29,17 @@ client.once("ready", () => {
 
 client.on("interactionCreate", interaction => {
     if (interaction.isCommand()) {
-        commandManager.commandImports
+        commandManager.commandByCommandName
             .get(interaction.commandName)
             .action(client, interaction);
+        return;
     }
 
-    if (interaction.isContextMenu()) {
-        commandManager.commandImports
+    if (interaction.isContextMenuCommand()) {
+        commandManager.commandByCommandName
             .get(interaction.commandName)
             .action(client, interaction);
+        return;
     }
 
     if (interaction.isButton()) {
@@ -47,6 +49,7 @@ client.on("interactionCreate", interaction => {
         } else if (interaction.customId.startsWith("changeRolesPage_")) {
             changeRolesPageEvent(client, interaction);
         }
+        return;
     }
 });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // Package imports
-const { Client, Intents } = require("discord.js");
+const { Client, GatewayIntentBits, ActivityType } = require("discord.js");
 
 // Custom imports
 const auth = require("./auth.json");
@@ -11,7 +11,7 @@ const { changeRolesPageEvent } = require("./events/changeRolesPage");
 
 // Client Instance
 const client = new Client({
-    intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MEMBERS],
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers],
 });
 
 // On ready
@@ -23,7 +23,7 @@ client.once("ready", () => {
 
     // Set presence
     client.user.setPresence({
-        activities: [{ type: "LISTENING", name: "the rain" }],
+        activities: [{ type: ActivityType.Listening, name: "the rain" }],
     });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "bufferutil": "^4.0.6",
-                "discord.js": "^13.8.0",
+                "discord.js": "^14.17.3",
                 "file-type": "^16.5.3",
                 "node-gyp": "^9.0.0",
                 "saucenao": "^0.0.2",
@@ -128,32 +128,130 @@
             }
         },
         "node_modules/@discordjs/builders": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-            "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
-            "deprecated": "no longer supported",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.10.0.tgz",
+            "integrity": "sha512-ikVZsZP+3shmVJ5S1oM+7SveUCK3L9fTyfA8aJ7uD9cNQlTqF+3Irbk2Y22KXTb3C3RNUahRkSInClJMkHrINg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@sapphire/shapeshift": "^3.5.1",
-                "discord-api-types": "^0.36.2",
+                "@discordjs/formatters": "^0.6.0",
+                "@discordjs/util": "^1.1.1",
+                "@sapphire/shapeshift": "^4.0.0",
+                "discord-api-types": "^0.37.114",
                 "fast-deep-equal": "^3.1.3",
-                "ts-mixer": "^6.0.1",
-                "tslib": "^2.4.0"
+                "ts-mixer": "^6.0.4",
+                "tslib": "^2.6.3"
             },
             "engines": {
-                "node": ">=16.9.0"
+                "node": ">=16.11.0"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
             }
         },
-        "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-            "version": "0.36.3",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-            "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
-        },
         "node_modules/@discordjs/collection": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-            "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+            "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+            "license": "Apache-2.0",
             "engines": {
-                "node": ">=16.9.0"
+                "node": ">=16.11.0"
+            }
+        },
+        "node_modules/@discordjs/formatters": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0.tgz",
+            "integrity": "sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "discord-api-types": "^0.37.114"
+            },
+            "engines": {
+                "node": ">=16.11.0"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/rest": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.2.tgz",
+            "integrity": "sha512-9bOvXYLQd5IBg/kKGuEFq3cstVxAMJ6wMxO2U3wjrgO+lHv8oNCT+BBRpuzVQh7BoXKvk/gpajceGvQUiRoJ8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@discordjs/collection": "^2.1.1",
+                "@discordjs/util": "^1.1.1",
+                "@sapphire/async-queue": "^1.5.3",
+                "@sapphire/snowflake": "^3.5.3",
+                "@vladfrangu/async_event_emitter": "^2.4.6",
+                "discord-api-types": "^0.37.114",
+                "magic-bytes.js": "^1.10.0",
+                "tslib": "^2.6.3",
+                "undici": "6.19.8"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+            "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/util": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+            "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/ws": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.0.tgz",
+            "integrity": "sha512-QH5CAFe3wHDiedbO+EI3OOiyipwWd+Q6BdoFZUw/Wf2fw5Cv2fgU/9UEtJRmJa9RecI+TAhdGPadMaEIur5yJg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@discordjs/collection": "^2.1.0",
+                "@discordjs/rest": "^2.4.1",
+                "@discordjs/util": "^1.1.0",
+                "@sapphire/async-queue": "^1.5.2",
+                "@types/ws": "^8.5.10",
+                "@vladfrangu/async_event_emitter": "^2.2.4",
+                "discord-api-types": "^0.37.114",
+                "tslib": "^2.6.2",
+                "ws": "^8.17.0"
+            },
+            "engines": {
+                "node": ">=16.11.0"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+            "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -226,22 +324,33 @@
             }
         },
         "node_modules/@sapphire/async-queue": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-            "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+            "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=v14.0.0",
                 "npm": ">=7.0.0"
             }
         },
         "node_modules/@sapphire/shapeshift": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.2.tgz",
-            "integrity": "sha512-NXpnJAsxN3/h9TqQPntOeVWZrpIuucqXI3IWF6tj2fWCoRLCuVK5wx7Dtg7pRrtkYfsMUbDqgKoX26vrC5iYfA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+            "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "lodash": "^4.17.21"
             },
+            "engines": {
+                "node": ">=v16"
+            }
+        },
+        "node_modules/@sapphire/snowflake": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+            "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=v14.0.0",
                 "npm": ">=7.0.0"
@@ -261,38 +370,31 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "18.16.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
-            "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
-        },
-        "node_modules/@types/node-fetch": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
-            "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+            "version": "22.13.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
+            "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-            }
-        },
-        "node_modules/@types/node-fetch/node_modules/form-data": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
+                "undici-types": "~6.20.0"
             }
         },
         "node_modules/@types/ws": {
-            "version": "8.5.4",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-            "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+            "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@vladfrangu/async_event_emitter": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+            "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
             }
         },
         "node_modules/abbrev": {
@@ -762,28 +864,35 @@
             }
         },
         "node_modules/discord-api-types": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-            "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+            "version": "0.37.118",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.118.tgz",
+            "integrity": "sha512-MQkHHZcytmNQ3nQOBj6a0z38swsmHiROX7hdayfd0eWVrLxaQp/6tWBZ7FO2MCKKsc+W3QWnnfOJTbtyk8C4TQ==",
+            "license": "MIT"
         },
         "node_modules/discord.js": {
-            "version": "13.15.1",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.15.1.tgz",
-            "integrity": "sha512-oZPG74FFK5Nd0QOMPU4YXm6RmKTG//WEIcgclKLmIIdOVFdQUSP0UBEK95J8431YZusiB7ZAjak9RjGIe1/0bQ==",
+            "version": "14.17.3",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.17.3.tgz",
+            "integrity": "sha512-8/j8udc3CU7dz3Eqch64UaSHoJtUT6IXK4da5ixjbav4NAXJicloWswD/iwn1ImZEMoAV3LscsdO0zhBh6H+0Q==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@discordjs/builders": "^0.16.0",
-                "@discordjs/collection": "^0.7.0",
-                "@sapphire/async-queue": "^1.5.0",
-                "@types/node-fetch": "^2.6.3",
-                "@types/ws": "^8.5.4",
-                "discord-api-types": "^0.33.5",
-                "form-data": "^4.0.0",
-                "node-fetch": "^2.6.7",
-                "ws": "^8.13.0"
+                "@discordjs/builders": "^1.10.0",
+                "@discordjs/collection": "1.5.3",
+                "@discordjs/formatters": "^0.6.0",
+                "@discordjs/rest": "^2.4.2",
+                "@discordjs/util": "^1.1.1",
+                "@discordjs/ws": "^1.2.0",
+                "@sapphire/snowflake": "3.5.3",
+                "discord-api-types": "^0.37.114",
+                "fast-deep-equal": "3.1.3",
+                "lodash.snakecase": "4.1.1",
+                "tslib": "^2.6.3",
+                "undici": "6.19.8"
             },
             "engines": {
-                "node": ">=16.6.0",
-                "npm": ">=7.0.0"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
             }
         },
         "node_modules/doctrine": {
@@ -1151,19 +1260,6 @@
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/fs-minipass": {
@@ -1585,6 +1681,12 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
+        "node_modules/lodash.snakecase": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+            "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+            "license": "MIT"
+        },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -1601,6 +1703,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/magic-bytes.js": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+            "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+            "license": "MIT"
         },
         "node_modules/make-fetch-happen": {
             "version": "10.1.7",
@@ -1782,25 +1890,6 @@
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
             }
         },
         "node_modules/node-gyp": {
@@ -2579,20 +2668,17 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
         "node_modules/ts-mixer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-            "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+            "license": "MIT"
         },
         "node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -2633,6 +2719,21 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+        },
+        "node_modules/undici": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+            "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "license": "MIT"
         },
         "node_modules/unique-filename": {
             "version": "1.1.1",
@@ -2703,20 +2804,6 @@
                 "extsprintf": "^1.2.0"
             }
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2754,9 +2841,10 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -2874,28 +2962,82 @@
             }
         },
         "@discordjs/builders": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-            "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.10.0.tgz",
+            "integrity": "sha512-ikVZsZP+3shmVJ5S1oM+7SveUCK3L9fTyfA8aJ7uD9cNQlTqF+3Irbk2Y22KXTb3C3RNUahRkSInClJMkHrINg==",
             "requires": {
-                "@sapphire/shapeshift": "^3.5.1",
-                "discord-api-types": "^0.36.2",
+                "@discordjs/formatters": "^0.6.0",
+                "@discordjs/util": "^1.1.1",
+                "@sapphire/shapeshift": "^4.0.0",
+                "discord-api-types": "^0.37.114",
                 "fast-deep-equal": "^3.1.3",
-                "ts-mixer": "^6.0.1",
-                "tslib": "^2.4.0"
-            },
-            "dependencies": {
-                "discord-api-types": {
-                    "version": "0.36.3",
-                    "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-                    "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
-                }
+                "ts-mixer": "^6.0.4",
+                "tslib": "^2.6.3"
             }
         },
         "@discordjs/collection": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-            "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+            "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="
+        },
+        "@discordjs/formatters": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0.tgz",
+            "integrity": "sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw==",
+            "requires": {
+                "discord-api-types": "^0.37.114"
+            }
+        },
+        "@discordjs/rest": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.2.tgz",
+            "integrity": "sha512-9bOvXYLQd5IBg/kKGuEFq3cstVxAMJ6wMxO2U3wjrgO+lHv8oNCT+BBRpuzVQh7BoXKvk/gpajceGvQUiRoJ8g==",
+            "requires": {
+                "@discordjs/collection": "^2.1.1",
+                "@discordjs/util": "^1.1.1",
+                "@sapphire/async-queue": "^1.5.3",
+                "@sapphire/snowflake": "^3.5.3",
+                "@vladfrangu/async_event_emitter": "^2.4.6",
+                "discord-api-types": "^0.37.114",
+                "magic-bytes.js": "^1.10.0",
+                "tslib": "^2.6.3",
+                "undici": "6.19.8"
+            },
+            "dependencies": {
+                "@discordjs/collection": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+                    "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="
+                }
+            }
+        },
+        "@discordjs/util": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+            "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g=="
+        },
+        "@discordjs/ws": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.0.tgz",
+            "integrity": "sha512-QH5CAFe3wHDiedbO+EI3OOiyipwWd+Q6BdoFZUw/Wf2fw5Cv2fgU/9UEtJRmJa9RecI+TAhdGPadMaEIur5yJg==",
+            "requires": {
+                "@discordjs/collection": "^2.1.0",
+                "@discordjs/rest": "^2.4.1",
+                "@discordjs/util": "^1.1.0",
+                "@sapphire/async-queue": "^1.5.2",
+                "@types/ws": "^8.5.10",
+                "@vladfrangu/async_event_emitter": "^2.2.4",
+                "discord-api-types": "^0.37.114",
+                "tslib": "^2.6.2",
+                "ws": "^8.17.0"
+            },
+            "dependencies": {
+                "@discordjs/collection": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+                    "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="
+                }
+            }
         },
         "@eslint/eslintrc": {
             "version": "0.4.3",
@@ -2955,18 +3097,23 @@
             }
         },
         "@sapphire/async-queue": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-            "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+            "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="
         },
         "@sapphire/shapeshift": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.2.tgz",
-            "integrity": "sha512-NXpnJAsxN3/h9TqQPntOeVWZrpIuucqXI3IWF6tj2fWCoRLCuVK5wx7Dtg7pRrtkYfsMUbDqgKoX26vrC5iYfA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+            "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
             "requires": {
                 "fast-deep-equal": "^3.1.3",
                 "lodash": "^4.17.21"
             }
+        },
+        "@sapphire/snowflake": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+            "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
         },
         "@tokenizer/token": {
             "version": "0.3.0",
@@ -2979,38 +3126,25 @@
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
         },
         "@types/node": {
-            "version": "18.16.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
-            "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
-        },
-        "@types/node-fetch": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
-            "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+            "version": "22.13.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
+            "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
             "requires": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-                    "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
-                    }
-                }
+                "undici-types": "~6.20.0"
             }
         },
         "@types/ws": {
-            "version": "8.5.4",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-            "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+            "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@vladfrangu/async_event_emitter": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+            "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -3375,24 +3509,27 @@
             "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
         },
         "discord-api-types": {
-            "version": "0.33.5",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-            "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+            "version": "0.37.118",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.118.tgz",
+            "integrity": "sha512-MQkHHZcytmNQ3nQOBj6a0z38swsmHiROX7hdayfd0eWVrLxaQp/6tWBZ7FO2MCKKsc+W3QWnnfOJTbtyk8C4TQ=="
         },
         "discord.js": {
-            "version": "13.15.1",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.15.1.tgz",
-            "integrity": "sha512-oZPG74FFK5Nd0QOMPU4YXm6RmKTG//WEIcgclKLmIIdOVFdQUSP0UBEK95J8431YZusiB7ZAjak9RjGIe1/0bQ==",
+            "version": "14.17.3",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.17.3.tgz",
+            "integrity": "sha512-8/j8udc3CU7dz3Eqch64UaSHoJtUT6IXK4da5ixjbav4NAXJicloWswD/iwn1ImZEMoAV3LscsdO0zhBh6H+0Q==",
             "requires": {
-                "@discordjs/builders": "^0.16.0",
-                "@discordjs/collection": "^0.7.0",
-                "@sapphire/async-queue": "^1.5.0",
-                "@types/node-fetch": "^2.6.3",
-                "@types/ws": "^8.5.4",
-                "discord-api-types": "^0.33.5",
-                "form-data": "^4.0.0",
-                "node-fetch": "^2.6.7",
-                "ws": "^8.13.0"
+                "@discordjs/builders": "^1.10.0",
+                "@discordjs/collection": "1.5.3",
+                "@discordjs/formatters": "^0.6.0",
+                "@discordjs/rest": "^2.4.2",
+                "@discordjs/util": "^1.1.1",
+                "@discordjs/ws": "^1.2.0",
+                "@sapphire/snowflake": "3.5.3",
+                "discord-api-types": "^0.37.114",
+                "fast-deep-equal": "3.1.3",
+                "lodash.snakecase": "4.1.1",
+                "tslib": "^2.6.3",
+                "undici": "6.19.8"
             }
         },
         "doctrine": {
@@ -3676,16 +3813,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
-        },
-        "form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            }
         },
         "fs-minipass": {
             "version": "2.1.0",
@@ -4015,6 +4142,11 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
+        "lodash.snakecase": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+            "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+        },
         "lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -4028,6 +4160,11 @@
             "requires": {
                 "yallist": "^4.0.0"
             }
+        },
+        "magic-bytes.js": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+            "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
         },
         "make-fetch-happen": {
             "version": "10.1.7",
@@ -4165,14 +4302,6 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-        },
-        "node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "requires": {
-                "whatwg-url": "^5.0.0"
-            }
         },
         "node-gyp": {
             "version": "9.0.0",
@@ -4732,20 +4861,15 @@
                 "punycode": "^2.1.1"
             }
         },
-        "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
         "ts-mixer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-            "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
         },
         "tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "tunnel-agent": {
             "version": "0.6.0",
@@ -4774,6 +4898,16 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+        },
+        "undici": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+            "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g=="
+        },
+        "undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
         },
         "unique-filename": {
             "version": "1.1.1",
@@ -4833,20 +4967,6 @@
                 "extsprintf": "^1.2.0"
             }
         },
-        "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4875,9 +4995,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "requires": {}
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/ecfidler/shigure-js#readme",
     "dependencies": {
         "bufferutil": "^4.0.6",
-        "discord.js": "^13.8.0",
+        "discord.js": "^14.17.3",
         "file-type": "^16.5.3",
         "node-gyp": "^9.0.0",
         "saucenao": "^0.0.2",

--- a/utilities/command-manager.js
+++ b/utilities/command-manager.js
@@ -10,7 +10,7 @@ async function loadCommands(client) {
     const commands = fs.readdirSync("./commands");
 
     const globalCommands = [];
-    const specializedCommands = new Map();
+    const specializedCommandsByGuildId = new Map();
     for (let i = 0; i < commands.length; i++) {
         const commandName = path.basename(commands[i], ".js");
         commandImports.set(commandName, require("../commands/" + commands[i]));
@@ -18,17 +18,25 @@ async function loadCommands(client) {
         if (!command.commandData.name) {
             command.commandData.name = commandName;
         }
+
         if (command.guild === "global") {
             globalCommands.push(command.commandData);
-        } else {
-            if (specializedCommands.has(command.guild)) {
-                specializedCommands
-                    .get(command.guild)
-                    .push(command.commandData);
-            } else {
-                specializedCommands.set(command.guild, [command.commandData]);
+        } else if (command.guild != null) {
+            pushOrCreate(
+                specializedCommandsByGuildId,
+                command.guild,
+                command.commandData
+            );
+        } else if (command.guilds != null) {
+            for (const guild of command.guilds) {
+                pushOrCreate(
+                    specializedCommandsByGuildId,
+                    guild,
+                    command.commandData
+                );
             }
         }
+
         console.info(`Loaded command: ${commandName}`);
     }
 
@@ -36,9 +44,9 @@ async function loadCommands(client) {
 
     const holUp = [];
 
-    specializedCommands.forEach(async (specialCommands, guildID) => {
+    specializedCommandsByGuildId.forEach((specialCommands, guildID) => {
         const guild = client.guilds.cache.get(guildID);
-        if (guild != undefined) {
+        if (guild != null) {
             holUp.push(guild.commands.set(specialCommands));
         } else {
             console.log("command is not in guild");
@@ -53,6 +61,7 @@ async function loadCommands(client) {
     holUp.push(client.application.commands.set(globalCommands));
 
     await Promise.all(holUp);
+    console.debug(holUp);
 
     console.info("Registered commands!");
 
@@ -101,6 +110,13 @@ async function loadCommands(client) {
   */
 }
 
+function pushOrCreate(map, key, value) {
+    if (map.has(key)) {
+        map.get(key).push(value);
+    } else {
+        map.set(key, [value]);
+    }
+}
 // function reloadCommands(client) {}
 
 // function reloadCommand(client) {}

--- a/utilities/command-manager.js
+++ b/utilities/command-manager.js
@@ -64,7 +64,6 @@ async function loadCommands(client) {
     holUp.push(client.application.commands.set(globalCommands));
 
     await Promise.all(holUp);
-    console.debug(holUp);
 
     console.info("Registered commands!");
 

--- a/utilities/command-manager.js
+++ b/utilities/command-manager.js
@@ -1,9 +1,9 @@
 const fs = require("fs");
 const path = require("path");
 
-const commandImports = new Map();
+const commandByCommandName = new Map();
 
-module.exports = { loadCommands, commandImports };
+module.exports = { loadCommands, commandByCommandName };
 
 async function loadCommands(client) {
     console.info("Loading commands...");
@@ -13,8 +13,11 @@ async function loadCommands(client) {
     const specializedCommandsByGuildId = new Map();
     for (let i = 0; i < commands.length; i++) {
         const commandName = path.basename(commands[i], ".js");
-        commandImports.set(commandName, require("../commands/" + commands[i]));
-        const command = commandImports.get(commandName);
+        commandByCommandName.set(
+            commandName,
+            require("../commands/" + commands[i])
+        );
+        const command = commandByCommandName.get(commandName);
         if (!command.commandData.name) {
             command.commandData.name = commandName;
         }
@@ -72,7 +75,7 @@ async function loadCommands(client) {
 
   client.guilds.cache.forEach((guild) => {
     guild.commands.cache.forEach((command) => {
-      const commandImport = commandImports.get(command.name);
+      const commandImport = commandByCommandName.get(command.name);
       if (commandImport.commandData.permissions) {
         holUp2.push(command.permissions.set({permissions: commandImport.commandData.permissions}));
       }
@@ -80,7 +83,7 @@ async function loadCommands(client) {
   });
 
   client.application.commands.cache.forEach((command) => {
-    const commandImport = commandImports.get(command.name);
+    const commandImport = commandByCommandName.get(command.name);
     if (commandImport.commandData.permissions) {
       holUp2.push(command.permissions.set({permissions: commandImport.commandData.permissions}));
     }

--- a/utilities/constants.js
+++ b/utilities/constants.js
@@ -3,11 +3,13 @@ const GUILDS = {
     YONI: "592214628550049794",
     TEST: "543283759407955974",
     ROLE: "906307865181048893",
+    BEN_TESTING: "571004411137097731",
     GLOBAL: "global",
 };
 
 const CHANNELS = {
     LOW: "580587430776930314", // lowlights channel in what have i done
+
     RULES: "592216496659496990", // rules channel in sauce emporium
     VALET: "675182191520776214", // welcome channel in sauce emporium
     MILD: "592222434396995604", // chef's choice mild in sauce emporium
@@ -17,6 +19,8 @@ const CHANNELS = {
     TPANTRY: "771774117422301215", // tbone's pantry in sauce emporium
     KITCHEN: "698708633831211078", // kitchen in sauce emporium
     FINDER: "592225004410896405", // sauce finder in sauce emporium
+
+    LOW_TEST: "674689826976694276", // spam in ben testing
 };
 
 const ROLES = {

--- a/utilities/roleup.js
+++ b/utilities/roleup.js
@@ -1,4 +1,4 @@
-const { MessageActionRow, MessageButton } = require("discord.js");
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 const {
     BUTTON_ROW_MAX_LENGTH,
     GUILDS,
@@ -33,15 +33,15 @@ function getButtonRowsWithPages(serverRoles, member, category, page) {
     moveToPage(page, serverRoles);
     rows.push(...makeRoleRows(MAXROLEROWS, serverRoles, member));
     rows.push(
-        new MessageActionRow().addComponents(
-            new MessageButton()
+        new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
                 .setLabel("<")
-                .setStyle("PRIMARY")
+                .setStyle(ButtonStyle.Primary)
                 .setCustomId(`changeRolesPage_${category}_${page - 1}`)
                 .setDisabled(page === 0),
-            new MessageButton()
+            new ButtonBuilder()
                 .setLabel(">")
-                .setStyle("PRIMARY")
+                .setStyle(ButtonStyle.Primary)
                 .setCustomId(`changeRolesPage_${category}_${page + 1}`)
                 .setDisabled(serverRoles.length === 0)
         )
@@ -67,14 +67,18 @@ function makeRoleRows(numRows, serverRoles, member) {
 }
 
 function makeRowOfRoles(serverRoles, member) {
-    const row = new MessageActionRow();
+    const row = new ActionRowBuilder();
     let j = 0;
     while (j < BUTTON_ROW_MAX_LENGTH && serverRoles.length > 0) {
         const role = serverRoles.shift();
         row.addComponents(
-            new MessageButton()
+            new ButtonBuilder()
                 .setLabel(role.name)
-                .setStyle(hasRole(member, role.id) ? "SUCCESS" : "SECONDARY")
+                .setStyle(
+                    hasRole(member, role.id)
+                        ? ButtonStyle.Success
+                        : ButtonStyle.Secondary
+                )
                 .setEmoji(role.emoji)
                 .setCustomId(`toggleRoleButton_${role.id}`)
         );


### PR DESCRIPTION
In order to use message forwarding, we need to be on discord.js version 14.17.0 or higher.

This PR updates our version of discord js and applies major version breaking changes as described in the [migration doc](https://discordjs.guide/additional-info/changes-in-v14.html).

---

I haven't tested this change yet since I don't have an official shigure js testing setup.